### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/filefinder2/_fileloader2.py
+++ b/filefinder2/_fileloader2.py
@@ -112,7 +112,7 @@ if (2, 7) <= sys.version_info < (3, 4):  # valid until which py3 version ?
 
         def get_code(self, fullname):
             source = self.get_source(fullname)
-            _verbose_message('compiling code for "%s"' % fullname)
+            _verbose_message('compiling code for "{0!s}"'.format(fullname))
             return compile(source, self.get_filename(fullname), 'exec', dont_inherit=True)
 
         def is_package(self, fullname):

--- a/filefinder2/tests/_utils.py
+++ b/filefinder2/tests/_utils.py
@@ -11,4 +11,4 @@ def print_importers():
     print('IMPORTERS:')
     for name, cache_value in sys.path_importer_cache.items():
         name = name.replace(sys.prefix, '...')
-        print('%s: %r' % (name, cache_value))
+        print('{0!s}: {1!r}'.format(name, cache_value))


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:asmodehn:filefinder2?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:asmodehn:filefinder2?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)